### PR TITLE
Fix empty vector and allow for int vector elements

### DIFF
--- a/src/Type/VectorType.php
+++ b/src/Type/VectorType.php
@@ -26,16 +26,20 @@ class VectorType extends Type
         return [];
     }
 
-    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): string
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
 
         if (!is_array($value) || count($value) === 0) {
-            return '[]';
+            return null;
         }
 
         $floats = array_filter($value, function ($item) {
             return is_float($item);
         });
+
+        if (count($floats) === 0) {
+            return null;
+        }
 
         return '[' . implode(',', $floats) . ']';
 

--- a/src/Type/VectorType.php
+++ b/src/Type/VectorType.php
@@ -33,15 +33,15 @@ class VectorType extends Type
             return null;
         }
 
-        $floats = array_filter($value, function ($item) {
-            return is_float($item);
+        $values = array_filter($value, function ($item) {
+            return is_float($item) || is_int($item);
         });
 
-        if (count($floats) === 0) {
+        if (count($values) == 0) {
             return null;
         }
 
-        return '[' . implode(',', $floats) . ']';
+        return '[' . implode(',', $values) . ']';
 
     }
 


### PR DESCRIPTION
1. Empty vectors are not allowed in [pgvector](https://github.com/pgvector/pgvector/blob/master/src/vector.c#L91).
2. `int` vector elements should be allowed.  The pgvector [readme](https://github.com/pgvector/pgvector/blob/master/README.md?plain=1#L76) documentation uses integers.


