### PR TITLE
Use Doctrine TokenType for ORM3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require": {
         "php": "^8.0",
-        "doctrine/dbal": "^3.6"
+        "doctrine/dbal": "^3.6",
+        "doctrine/orm": "^2.19|^3.0"
     }
 }

--- a/src/Query/CosineSimilarity.php
+++ b/src/Query/CosineSimilarity.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Partitech\DoctrinePgVector\Query;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class CosineSimilarity extends FunctionNode
 {
@@ -19,12 +19,12 @@ class CosineSimilarity extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->field = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->vector = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string


### PR DESCRIPTION
The TokenType Enum is introduced in 2.19 and const from Lexer are removed in 3.0